### PR TITLE
fill_arrayref() with multiple arrayref binds

### DIFF
--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -52,5 +52,14 @@ for my $func (@func) {
 
 is $dbh->connect_info->[0], 'dbi:SQLite::memory:';
 
+my ($query, @binds) = $dbh->fill_arrayref(
+    'SELECT * FROM foo WHERE e IN (?) OR e IN (?)',
+    [ 'a', 'b' ],
+    [ 'x', 'y', 'z' ],
+);
+
+is $query, 'SELECT * FROM foo WHERE e IN (?,?) OR e IN (?,?,?)';
+is_deeply \@binds, [ 'a', 'b', 'x', 'y', 'z' ];
+
 done_testing();
 


### PR DESCRIPTION
When querying methods like `$dbh->select_all` are called with multiple arrayref bind parameters, such as

```
$dbh->select_all(
    'SELECT * FROM foo WHERE e IN (?) OR e IN (?)',
    [ 'a', 'b' ],
    [ 'x', 'y', 'z' ],
);
```

Generated query's placeholders are misplaced:

```
SELECT * FROM foo WHERE e IN ('a','b','x','y') OR e IN ('z')
```

This pull-req fixes this problem, thus the query generated will be:

```
SELECT * FROM foo WHERE e IN ('a','b') OR e IN ('x','y','z')
```

よろしくお願いします。
