### PR TITLE
Perl 5.26+ removes dot from @INC.

### DIFF
--- a/t/lib/TestSchema.pm
+++ b/t/lib/TestSchema.pm
@@ -1,4 +1,4 @@
-package t::TestSchema;
+package TestSchema;
 
 use strict;
 use warnings;

--- a/t/schema_00_compile.t
+++ b/t/schema_00_compile.t
@@ -1,9 +1,10 @@
 use strict;
 use Test::More tests => 2;
+use lib 't/lib/';
 
 BEGIN {
     use_ok 'DBIx::Sunny::Schema';
-    use_ok 't::TestSchema';
+    use_ok 'TestSchema';
  }
 
 

--- a/t/schema_01_basic.t
+++ b/t/schema_01_basic.t
@@ -4,10 +4,11 @@ use Test::More;
 use Capture::Tiny qw/capture_merged/;
 use DBIx::Sunny;
 use Test::Requires { 'DBD::SQLite' => 1.27 };
-use t::TestSchema;
+use lib 't/lib/';
+use TestSchema;
 
 my $dbh = DBIx::Sunny->connect('dbi:SQLite::memory:', '', '');
-my $schema = t::TestSchema->new(dbh => $dbh);
+my $schema = TestSchema->new(dbh => $dbh);
 ok($schema);
 
 ok($schema->create_foo_t);
@@ -29,7 +30,7 @@ ok ! capture_merged { $schema->select_one_foo() };
 is_deeply $schema->select_row_foo(), { id=>1, e => 3 };
 ok ! capture_merged { $schema->select_row_foo() };
 
-is_deeply $schema->select_row_foo_filter(), { id=>1, e => 9, ref => 't::TestSchema' };
+is_deeply $schema->select_row_foo_filter(), { id=>1, e => 9, ref => 'TestSchema' };
 
 is join('|', map { $_->{e} } @{$schema->select_all_foo()}), '3|4';
 is_deeply $schema->select_all_foo(limit=>1), [{ id=>1, e => 3 }];

--- a/t/schema_03_txn.t
+++ b/t/schema_03_txn.t
@@ -3,12 +3,13 @@ use warnings;
 use Test::More;
 use Test::Requires { 'DBD::SQLite' => 1.27 };
 use DBIx::Sunny;
-use t::TestSchema;
+use lib 't/lib/';
+use TestSchema;
 
 
 subtest 'x' => sub {
     my $dbh = DBIx::Sunny->connect('dbi:SQLite::memory:', '', '');
-    my $schema = t::TestSchema->new(dbh => $dbh);
+    my $schema = TestSchema->new(dbh => $dbh);
     $schema->create_foo_t();
     $schema->insert_foo(e=>1);
     {

--- a/t/scheme_02_args.t
+++ b/t/scheme_02_args.t
@@ -4,10 +4,11 @@ use Test::More;
 use Time::localtime;
 use DBIx::Sunny;
 use Test::Requires { 'DBD::SQLite' => 1.27 };
-use t::TestSchema;
+use lib 't/lib/';
+use TestSchema;
 
 my $dbh = DBIx::Sunny->connect('dbi:SQLite::memory:', '', '');
-my $schema = t::TestSchema->new(dbh => $dbh);
+my $schema = TestSchema->new(dbh => $dbh);
 
 my $created = localtime;
 is( $schema->deflate_args(created=>$created), 'TestTm');


### PR DESCRIPTION
https://www.effectiveperlprogramming.com/2017/01/v5-26-removes-dot-from-inc/