### PR TITLE
The comment insertion mechanism to work correctly when used with DBIx::Class

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -12,4 +12,6 @@ on test => sub {
     requires 'Test::More', '0.98';
     requires 'Test::Requires';
     requires 'Test::TCP';
+    recommends 'DBIx::Class', '0.082840';
+    recommends 'DBIx::Tracer', '0.03';
 };

--- a/lib/DBIx/Sunny.pm
+++ b/lib/DBIx/Sunny.pm
@@ -81,7 +81,7 @@ sub __set_comment {
         my $file = $caller[1];
         $file =~ s!\*/!*\//!g;
         $trace = "/* $file line $caller[2] */"; 
-        last if $caller[0] ne ref($self) && $caller[0] !~ /^(:?DBIx?|DBD)\b/;
+        last if $caller[0] ne ref($self) && $caller[0] !~ /^(:?DBIx?|DBD|Try::Tiny|Context::Preserve)\b/;
         $i++;
     }
     $query =~ s! ! $trace !;

--- a/t/06_dbic.t
+++ b/t/06_dbic.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Test::Requires { 'DBD::SQLite' => 1.27, 'DBIx::Class' => 0.082840, 'DBIx::Tracer' => 0.03 };
+use File::Temp qw/tempdir/;
+use DBIx::Sunny;
+use Data::Dumper;
+use lib 't/lib/';
+use MyApp::Schema;
+
+my $dir = tempdir( CLEANUP => 1 );
+my $fname = "$dir/db.sqlite";
+
+my $schema = MyApp::Schema->connect("dbi:SQLite:dbname=$fname", '', '', {
+    RootClass => 'DBIx::Sunny',
+    on_connect_do => q{
+        CREATE TABLE foo (
+            id INTEGER NOT NULL PRIMARY KEY,
+            e VARCHAR(10)
+        )
+    },
+});
+my @queries;
+my $tracer = DBIx::Tracer->new(
+    sub {
+        my %args = @_;
+        push @queries, $args{sql};
+    }
+);
+my @rows = $schema->resultset('Foo')->all;
+is 0+@rows, 0;
+cmp_ok(0+(grep m{/\* t.06_dbic.t line 31 \*/}, @queries), '>', 0);
+note Dumper(\@queries);
+
+done_testing;
+

--- a/t/lib/MyApp/Schema.pm
+++ b/t/lib/MyApp/Schema.pm
@@ -1,0 +1,11 @@
+package MyApp::Schema;
+use strict;
+use warnings;
+use utf8;
+
+use base qw/DBIx::Class::Schema/;
+
+__PACKAGE__->load_namespaces();
+
+1;
+

--- a/t/lib/MyApp/Schema/Result/Foo.pm
+++ b/t/lib/MyApp/Schema/Result/Foo.pm
@@ -1,0 +1,14 @@
+package MyApp::Schema::Result::Foo;
+use strict;
+use warnings;
+use utf8;
+use 5.010_001;
+
+use parent qw/DBIx::Class::Core/;
+    
+__PACKAGE__->table('foo');
+__PACKAGE__->add_columns(qw/ id e /);
+__PACKAGE__->set_primary_key('id');
+
+1;
+

--- a/t/lib/TestSchema.pm
+++ b/t/lib/TestSchema.pm
@@ -1,4 +1,4 @@
-package t::TestSchema;
+package TestSchema;
 
 use strict;
 use warnings;

--- a/t/schema_00_compile.t
+++ b/t/schema_00_compile.t
@@ -1,9 +1,10 @@
 use strict;
 use Test::More tests => 2;
+use lib 't/lib/';
 
 BEGIN {
     use_ok 'DBIx::Sunny::Schema';
-    use_ok 't::TestSchema';
+    use_ok 'TestSchema';
  }
 
 

--- a/t/schema_01_basic.t
+++ b/t/schema_01_basic.t
@@ -4,10 +4,11 @@ use Test::More;
 use Capture::Tiny qw/capture_merged/;
 use DBIx::Sunny;
 use Test::Requires { 'DBD::SQLite' => 1.27 };
-use t::TestSchema;
+use lib 't/lib/';
+use TestSchema;
 
 my $dbh = DBIx::Sunny->connect('dbi:SQLite::memory:', '', '');
-my $schema = t::TestSchema->new(dbh => $dbh);
+my $schema = TestSchema->new(dbh => $dbh);
 ok($schema);
 
 ok($schema->create_foo_t);
@@ -29,7 +30,7 @@ ok ! capture_merged { $schema->select_one_foo() };
 is_deeply $schema->select_row_foo(), { id=>1, e => 3 };
 ok ! capture_merged { $schema->select_row_foo() };
 
-is_deeply $schema->select_row_foo_filter(), { id=>1, e => 9, ref => 't::TestSchema' };
+is_deeply $schema->select_row_foo_filter(), { id=>1, e => 9, ref => 'TestSchema' };
 
 is join('|', map { $_->{e} } @{$schema->select_all_foo()}), '3|4';
 is_deeply $schema->select_all_foo(limit=>1), [{ id=>1, e => 3 }];

--- a/t/schema_03_txn.t
+++ b/t/schema_03_txn.t
@@ -3,12 +3,13 @@ use warnings;
 use Test::More;
 use Test::Requires { 'DBD::SQLite' => 1.27 };
 use DBIx::Sunny;
-use t::TestSchema;
+use lib 't/lib/';
+use TestSchema;
 
 
 subtest 'x' => sub {
     my $dbh = DBIx::Sunny->connect('dbi:SQLite::memory:', '', '');
-    my $schema = t::TestSchema->new(dbh => $dbh);
+    my $schema = TestSchema->new(dbh => $dbh);
     $schema->create_foo_t();
     $schema->insert_foo(e=>1);
     {

--- a/t/scheme_02_args.t
+++ b/t/scheme_02_args.t
@@ -4,10 +4,11 @@ use Test::More;
 use Time::localtime;
 use DBIx::Sunny;
 use Test::Requires { 'DBD::SQLite' => 1.27 };
-use t::TestSchema;
+use lib 't/lib/';
+use TestSchema;
 
 my $dbh = DBIx::Sunny->connect('dbi:SQLite::memory:', '', '');
-my $schema = t::TestSchema->new(dbh => $dbh);
+my $schema = TestSchema->new(dbh => $dbh);
 
 my $created = localtime;
 is( $schema->deflate_args(created=>$created), 'TestTm');


### PR DESCRIPTION
    AS-IS: SELECT /* /Users/tokuhirom/.plenv/versions/5.26.0-RC1/lib/perl5/site_perl/5.26.0/Try/Tiny.pm line 99 */ me.id, me.e FROM foo me
    TO-BE: SELECT /* t/06_dbic.t line 31 */ me.id, me.e FROM foo me
