### PR TITLE
Configurable to skip caller packages.

### DIFF
--- a/lib/DBIx/Sunny.pm
+++ b/lib/DBIx/Sunny.pm
@@ -6,6 +6,7 @@ use 5.008005;
 use DBI 1.615;
 
 our $VERSION = '0.24';
+our $SKIP_CALLER_REGEX = qr/^(:?DBIx?|DBD|Try::Tiny|Context::Preserve)\b/;
 
 use parent qw/DBI/;
 
@@ -80,8 +81,8 @@ sub __set_comment {
     while ( my @caller = caller($i) ) {
         my $file = $caller[1];
         $file =~ s!\*/!*\//!g;
-        $trace = "/* $file line $caller[2] */"; 
-        last if $caller[0] ne ref($self) && $caller[0] !~ /^(:?DBIx?|DBD|Try::Tiny|Context::Preserve)\b/;
+        $trace = "/* $file line $caller[2] */";
+        last if $caller[0] ne ref($self) && $caller[0] !~ $SKIP_CALLER_REGEX;
         $i++;
     }
     $query =~ s! ! $trace !;

--- a/t/07_caller.t
+++ b/t/07_caller.t
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Test::Requires { 'DBD::SQLite' => 1.27, 'DBIx::Class' => 0.082840, 'DBIx::Tracer' => 0.03 };
+use File::Temp qw/tempdir/;
+use DBIx::Sunny;
+use Data::Dumper;
+use lib 't/lib/';
+use MyApp::Schema;
+use MyApp;
+
+# skip MyApp in caller
+local $DBIx::Sunny::SKIP_CALLER_REGEX = qr/^(:?DBIx?|DBD|Try::Tiny|Context::Preserve|MyApp)\b/;
+
+my $dir = tempdir( CLEANUP => 1 );
+my $fname = "$dir/db.sqlite";
+
+my $schema = MyApp::Schema->connect("dbi:SQLite:dbname=$fname", '', '', {
+    RootClass => 'DBIx::Sunny',
+    on_connect_do => q{
+        CREATE TABLE foo (
+            id INTEGER NOT NULL PRIMARY KEY,
+            e VARCHAR(10)
+        )
+    },
+});
+
+my @queries;
+my $tracer = DBIx::Tracer->new(
+    sub {
+        my %args = @_;
+        push @queries, $args{sql};
+    }
+);
+my @rows = MyApp->foo_all($schema);
+is 0+@rows, 0;
+cmp_ok(0+(grep m{/\* t.07_caller.t line 36 \*/}, @queries), '>', 0);
+note Dumper(\@queries);
+
+done_testing;
+

--- a/t/lib/MyApp.pm
+++ b/t/lib/MyApp.pm
@@ -1,0 +1,11 @@
+package MyApp;
+use strict;
+use warnings;
+use utf8;
+
+sub foo_all {
+    my ($class, $schema) = @_;
+    $schema->resultset('Foo')->all;
+}
+
+1;


### PR DESCRIPTION
Introduce $SKIP_CALLER_REGEX package variable instead of hard coded regex.

I hope to ignore some packages in caller which used as common in my application.