### PR TITLE
Warn mismatch of bind values

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -17,6 +17,7 @@ on test => sub {
     requires 'Capture::Tiny';
     requires 'Test::More', '0.98';
     requires 'Test::Requires';
+    requires 'Test::Warn';
 };
 
 on develop => sub {

--- a/cpanfile
+++ b/cpanfile
@@ -17,7 +17,7 @@ on test => sub {
     requires 'Capture::Tiny';
     requires 'Test::More', '0.98';
     requires 'Test::Requires';
-    requires 'Test::Warn';
+    requires 'Test::Exception';
 };
 
 on develop => sub {

--- a/lib/DBIx/Sunny/Util.pm
+++ b/lib/DBIx/Sunny/Util.pm
@@ -33,8 +33,11 @@ sub expand_placeholder {
     }
 
     my @bind_param;
+    my $orig_num_binds = @bind;
+    my $num_bounds = 0;
     $query =~ s{\?}{
         my $bind = shift @bind;
+        $num_bounds++;
         if (ref($bind) && ref($bind) eq 'ARRAY') {
             push @bind_param, @$bind;
             join ',', ('?') x @$bind;
@@ -43,6 +46,11 @@ sub expand_placeholder {
             '?';
         }
     }ge;
+
+    if ($num_bounds != $orig_num_binds) {
+        warn "Num of binds doesn't match. expected = $num_bounds, but passed $orig_num_binds";
+    }
+
     return ( $query, @bind_param );
 }
 

--- a/lib/DBIx/Sunny/Util.pm
+++ b/lib/DBIx/Sunny/Util.pm
@@ -6,6 +6,7 @@ use warnings;
 use Exporter 'import';
 use Scalar::Util qw/blessed/;
 use SQL::NamedPlaceholder 0.10;
+use Carp qw/croak/;
 
 our @EXPORT_OK = qw/bind_and_execute expand_placeholder/;
 
@@ -48,7 +49,7 @@ sub expand_placeholder {
     }ge;
 
     if ($num_bounds != $orig_num_binds) {
-        warn "Num of binds doesn't match. expected = $num_bounds, but passed $orig_num_binds";
+        croak "Num of binds doesn't match. expected = $num_bounds, but passed $orig_num_binds";
     }
 
     return ( $query, @bind_param );

--- a/t/10_binds_mismatch.t
+++ b/t/10_binds_mismatch.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Warn;
+use DBIx::Sunny::Util qw/expand_placeholder/;
+
+my $exp_warn = qr/Num of binds doesn't match/;
+
+subtest 'no placeholder' => sub {
+    my $sql = q{SELECT * FROM foo};
+
+    warning_is { expand_placeholder($sql) } undef, 'exact';
+    warning_like { expand_placeholder($sql, 1) } $exp_warn, 'too many';
+    warning_like { expand_placeholder($sql, undef) } $exp_warn, 'too many';
+};
+
+subtest 'scalar' => sub {
+    my $sql = q{SELECT * FROM foo WHERE id = ?};
+
+    warning_like { expand_placeholder($sql) } $exp_warn, 'too few';
+    warning_is { expand_placeholder($sql, 1) } undef, 'exact';
+    warning_is { expand_placeholder($sql, undef) } undef, 'exact';
+    warning_like { expand_placeholder($sql, 1, 2) } $exp_warn, 'too many';
+    warning_like { expand_placeholder($sql, 1, undef) } $exp_warn, 'too many';
+};
+
+subtest 'has array' => sub {
+    my $sql = q{SELECT * FROM foo WHERE id IN (?)};
+
+    warning_like { expand_placeholder($sql) } $exp_warn, 'too few';
+    warning_is { expand_placeholder($sql, [1, 2]) } undef, 'exact';
+    warning_is { expand_placeholder($sql, [undef]) } undef, 'exact';
+    warning_like { expand_placeholder($sql, [1, 2], 3) } $exp_warn, 'too many';
+    warning_like { expand_placeholder($sql, [1, 2], undef) } $exp_warn, 'too many';
+};
+
+done_testing;

--- a/t/10_binds_mismatch.t
+++ b/t/10_binds_mismatch.t
@@ -1,37 +1,37 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::Warn;
+use Test::Exception;
 use DBIx::Sunny::Util qw/expand_placeholder/;
 
-my $exp_warn = qr/Num of binds doesn't match/;
+my $exp_throw = qr/Num of binds doesn't match/;
 
 subtest 'no placeholder' => sub {
     my $sql = q{SELECT * FROM foo};
 
-    warning_is { expand_placeholder($sql) } undef, 'exact';
-    warning_like { expand_placeholder($sql, 1) } $exp_warn, 'too many';
-    warning_like { expand_placeholder($sql, undef) } $exp_warn, 'too many';
+    lives_ok { expand_placeholder($sql) } 'exact';
+    throws_ok { expand_placeholder($sql, 1) } $exp_throw, 'too many';
+    throws_ok { expand_placeholder($sql, undef) } $exp_throw, 'too many';
 };
 
 subtest 'scalar' => sub {
     my $sql = q{SELECT * FROM foo WHERE id = ?};
 
-    warning_like { expand_placeholder($sql) } $exp_warn, 'too few';
-    warning_is { expand_placeholder($sql, 1) } undef, 'exact';
-    warning_is { expand_placeholder($sql, undef) } undef, 'exact';
-    warning_like { expand_placeholder($sql, 1, 2) } $exp_warn, 'too many';
-    warning_like { expand_placeholder($sql, 1, undef) } $exp_warn, 'too many';
+    throws_ok { expand_placeholder($sql) } $exp_throw, 'too few';
+    lives_ok { expand_placeholder($sql, 1) } 'exact';
+    lives_ok { expand_placeholder($sql, undef) } 'exact';
+    throws_ok { expand_placeholder($sql, 1, 2) } $exp_throw, 'too many';
+    throws_ok { expand_placeholder($sql, 1, undef) } $exp_throw, 'too many';
 };
 
 subtest 'has array' => sub {
     my $sql = q{SELECT * FROM foo WHERE id IN (?)};
 
-    warning_like { expand_placeholder($sql) } $exp_warn, 'too few';
-    warning_is { expand_placeholder($sql, [1, 2]) } undef, 'exact';
-    warning_is { expand_placeholder($sql, [undef]) } undef, 'exact';
-    warning_like { expand_placeholder($sql, [1, 2], 3) } $exp_warn, 'too many';
-    warning_like { expand_placeholder($sql, [1, 2], undef) } $exp_warn, 'too many';
+    throws_ok { expand_placeholder($sql) } $exp_throw, 'too few';
+    lives_ok { expand_placeholder($sql, [1, 2]) } 'exact';
+    lives_ok { expand_placeholder($sql, [undef]) } 'exact';
+    throws_ok { expand_placeholder($sql, [1, 2], 3) } $exp_throw, 'too many';
+    throws_ok { expand_placeholder($sql, [1, 2], undef) } $exp_throw, 'too many';
 };
 
 done_testing;


### PR DESCRIPTION
DBIx::Sunny's additional methods accepts bind values, even if the number of them doesn't match with the number of placeholders.

For example, `select_row` accepts the following usages:

~~~perl
$dbh->select_row("SELECT * FROM student WHERE id = ?");          # too few bind values
$dbh->select_row("SELECT * FROM student WHERE id = ?", 1, 2);   # too many bind values
~~~

They will issue the following query. (Output by using DBIx::QueryLog)

~~~
[2020-07-27T23:51:24] [DBIx::Sunny::Util] [0.000409] SELECT /* sunny_test.pl line 20 */ * FROM student WHERE id = NULL at lib/DBIx/Sunny/Util.pm line 23
[2020-07-27T23:51:24] [DBIx::Sunny::Util] [0.000364] SELECT /* sunny_test.pl line 21 */ * FROM student WHERE id = '1' at lib/DBIx/Sunny/Util.pm line 23
~~~

In the former case, placeholder is replaced with `NULL`. And in the latter, extra value `2` is ignored.

I think those mismatch would not be what the programmer would intend. It would be safe to warn them.

This PR checks the number of bind values and warn if it doesn't match with the number of placeholders.