### PR TITLE
Add select_row_as and select_all_as features

### DIFF
--- a/lib/DBIx/Sunny.pm
+++ b/lib/DBIx/Sunny.pm
@@ -159,6 +159,21 @@ sub last_insert_id {
     $self->SUPER::last_insert_id(@_);
 }
 
+sub select_row_as {
+    my $self = shift;
+    my $model = shift;
+    my $row = $self->select_row(@_);
+    return unless $row;
+    $model->new(%$row);
+}
+
+sub select_all_as {
+    my $self = shift;
+    my $model = shift;
+    my $rows = $self->select_all(@_);
+    return [ map { $model->new(%$_) } @$rows ];
+}
+
 package DBIx::Sunny::st; # statement handler
 our @ISA = qw(DBI::st);
 
@@ -178,7 +193,7 @@ DBIx::Sunny - Simple DBI wrapper
 
     my $dbh = DBIx::Sunny->connect(...);
 
-    # or 
+    # or
 
     use DBI;
 
@@ -277,9 +292,17 @@ Shortcut for prepare, execute and fetchrow_hashref
 
 Shortcut for prepare, execute and C<< selectall_arrayref(.., { Slice => {} }, ..) >>
 
+=item C<< $model = $dbh->select_row_as($model_class, $query, @bind); >>
+
+Shortcut for C<< $model_class->new(%{ $dbh->select_row($query, @bind) }) >>;
+
+=item C<< $models = $dbh->select_all_as($model_class, $query, @bind); >>
+
+Shortcut for C<< [ map { $model_class->new(%$_) } @{ $dbh->select_all($query, @bind) } ]; >>
+
 =item C<< $dbh->query($query, @bind); >>
 
-Shortcut for prepare, execute. 
+Shortcut for prepare, execute.
 
 =back
 

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -24,6 +24,30 @@ is_deeply $dbh->select_row(q{SELECT * FROM foo ORDER BY e}), { id => 1, e => 3 }
 is join('|', map { $_->{e} } @{$dbh->select_all(q{SELECT * FROM foo ORDER BY e})}), '3|4';
 is join('|', map { $_->{e} } @{$dbh->select_all(q{SELECT * FROM foo WHERE e IN (?)},[3,4])}), '3|4';
 
+
+{
+    package Foo;
+    sub new {
+        my ($class, %args) = @_;
+        bless \%args, $class;
+    }
+}
+
+subtest 'select_row_as' => sub {
+    my $foo = $dbh->select_row_as('Foo', q{SELECT e FROM foo WHERE id=?}, 1);
+    isa_ok $foo, 'Foo';
+    is $foo->{e}, 3;
+};
+
+subtest 'select_all_as' => sub {
+    my $foos = $dbh->select_all_as('Foo', q{SELECT * FROM foo ORDER BY e});
+    isa_ok $foos->[0], 'Foo';
+    is $foos->[0]->{e}, 3;
+
+    isa_ok $foos->[1], 'Foo';
+    is $foos->[1]->{e}, 4;
+};
+
 subtest 'utf8' => sub {
     use utf8;
     ok( $dbh->query(q{CREATE TABLE bar (x varchar(10))}) );


### PR DESCRIPTION
This pull request adds `select_row_as` and `select_all_as` methods.  These methods are shortcuts to create models like this:

```perl
class User {
  field $name :param
}

# BEFORE
my $user_row = $dbh->select_row('SELECT * FROM users LIMIT 1');
unless ($user_row) {
   return NOT_FOUND
}
my $user = User->new($user_row->%*);

# AFTER
my $user = $dbh->select_row_as('User', 'SELECT * FROM users LIMIT 1');
unless ($user) {
   return NOT_FOUND
}
```

Could you please add it?

